### PR TITLE
fix: remove lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@jcoreio/commitlint-config": "^1.1.1",
     "@types/chai": "^4.2.6",
     "@types/fs-extra": "^8.0.1",
-    "@types/lodash": "^4.14.155",
     "@types/mocha": "^5.2.7",
     "@types/touch": "^3.1.1",
     "@typescript-eslint/eslint-plugin": "^2.7.0",
@@ -114,7 +113,6 @@
     "typescript": "^3.7.2"
   },
   "dependencies": {
-    "lodash": "^4.17.15",
     "moment": "^2.27.0"
   },
   "renovate": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,24 +3,26 @@ import moment from 'moment'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export type Logger = {
-  trace: (...args: Array<any>) => void
-  debug: (...args: Array<any>) => void
-  info: (...args: Array<any>) => void
-  warn: (...args: Array<any>) => void
-  error: (...args: Array<any>) => void
-  fatal: (...args: Array<any>) => void
-  logAtLevel: (level: number, ...args: Array<any>) => void
-  levelEnabled: (level: number) => boolean
+export type Level = 1 | 2 | 3 | 4 | 5 | 6
+
+export interface Logger {
+  trace(...args: Array<any>): void
+  debug(...args: Array<any>): void
+  info(...args: Array<any>): void
+  warn(...args: Array<any>): void
+  error(...args: Array<any>): void
+  fatal(...args: Array<any>): void
+  logAtLevel(level: Level, ...args: Array<any>): void
+  levelEnabled(level: Level): boolean
 }
 
 export type LogProvider = (
   loggerPath: string,
-  level: number,
+  level: Level,
   ...args: Array<any>
 ) => void
 
-export type LogFunctionProvider = (level: number) => Function
+export type LogFunctionProvider = (level: Level) => Function
 
 export const LOG_LEVEL_TRACE = 1
 export const LOG_LEVEL_DEBUG = 2
@@ -47,10 +49,10 @@ const logLevelToName = {
 
 //const nameToLogLevel = invert(logLevelToName)
 
-const configuredLogLevels: { [path: string]: number } = {}
-const envLogLevels: { [path: string]: number } = {}
+const configuredLogLevels: { [path: string]: Level } = {}
+const envLogLevels: { [path: string]: Level } = {}
 
-const logLevelAtPath = (path: string): number | undefined =>
+const logLevelAtPath = (path: string): Level | undefined =>
   configuredLogLevels[path] || envLogLevels[path]
 
 const envVar = (varName: string): string | undefined =>
@@ -64,15 +66,15 @@ const calcEnvLogLevels = once(() => {
     if (envForLevel && isString(envForLevel)) {
       const targetsForLevel = compact(envForLevel.split(','))
       targetsForLevel.forEach((target: string) => {
-        envLogLevels[target] = logLevel
+        envLogLevels[target] = logLevel as Level
       })
     }
   }
 })
 
-let logLevelsCache: { [path: string]: number } = {}
+let logLevelsCache: { [path: string]: Level } = {}
 
-export function setLogLevel(path: string, level: number): void {
+export function setLogLevel(path: string, level: Level): void {
   if (!isInteger(level)) throw Error('log level must be an integer')
   if (level < LOG_LEVEL_TRACE || level > LOG_LEVEL_FATAL)
     throw Error(
@@ -85,9 +87,9 @@ export function setLogLevel(path: string, level: number): void {
   }
 }
 
-function calcLogLevel(path: string): number {
+function calcLogLevel(path: string): Level {
   calcEnvLogLevels()
-  const levelAtExactPath: number | undefined = logLevelAtPath(path)
+  const levelAtExactPath: Level | undefined = logLevelAtPath(path)
   if (levelAtExactPath != null) return levelAtExactPath
   const exactPathSplit = path.split(PATH_SEPARATOR)
   for (
@@ -96,14 +98,14 @@ function calcLogLevel(path: string): number {
     --compareLen
   ) {
     const subPath = exactPathSplit.slice(0, compareLen).join(PATH_SEPARATOR)
-    const levelAtSubPath: number | undefined = logLevelAtPath(subPath)
+    const levelAtSubPath: Level | undefined = logLevelAtPath(subPath)
     if (levelAtSubPath != null) return levelAtSubPath
   }
   return DEFAULT_LOG_LEVEL
 }
 
-function logLevel(path: string): number {
-  let levelForPath: number | undefined = logLevelsCache[path]
+function logLevel(path: string): Level {
+  let levelForPath: Level | undefined = logLevelsCache[path]
   if (levelForPath == null) {
     logLevelsCache[path] = levelForPath = calcLogLevel(path)
   }
@@ -112,7 +114,7 @@ function logLevel(path: string): number {
 
 const hasDate = !envVar('LOG_NO_DATE')
 
-const defaultLogFunctionProvider: LogFunctionProvider = (level: number) =>
+const defaultLogFunctionProvider: LogFunctionProvider = (level: Level) =>
   level >= LOG_LEVEL_ERROR ? console.error : console.log // eslint-disable-line no-console
 
 let _logFunctionProvider: LogFunctionProvider = defaultLogFunctionProvider
@@ -128,7 +130,7 @@ export function setLogFunctionProvider(provider: LogFunctionProvider): void {
 
 const defaultLogProvider: LogProvider = (
   loggerPath: string,
-  level: number,
+  level: Level,
   ...args: Array<any>
 ) => {
   const logFunc: Function = _logFunctionProvider(level)
@@ -149,7 +151,7 @@ export function setLogProvider(provider: LogProvider): void {
 const loggersByPath: { [loggerPath: string]: Logger } = {}
 
 function createLogger(loggerPath: string): Logger {
-  const logAtLevel = (level: number, ...args: Array<any>): void => {
+  const logAtLevel = (level: Level, ...args: Array<any>): void => {
     if (level >= logLevel(loggerPath)) {
       let argsToLogger: Array<any> = args
       if (args.length === 1 && isFunction(args[0])) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,11 +1099,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
-"@types/lodash@^4.14.155":
-  version "4.14.155"
-  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.155.tgz#e2b4514f46a261fd11542e47519c20ebce7bc23a"
-  integrity sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==
-
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"


### PR DESCRIPTION
it's too easy to avoid using lodash to justify having it as a dependency IMO.

The only real point of `isFunction` is to use it as a predicate like `arr.filter(isFunction)`.
It's trivial:
```
function isFunction(value) {
  return typeof value === 'function'
}
```

`isString` accepts primitive strings and also instances of the `String` class, but I don't know
anyone who's in favor of using the `String` class for anything.

```
function isString(value) {
  const type = typeof value
  return type === 'string' || (type === 'object' && value != null && !Array.isArray(value) && getTag(value) == '[object String]')
}
```

We were using `isInteger` to validate the `level` passed to one method, but that would fail to catch log levels that are out
of range, so I replaced it with a strict check that the value is one of the valid log levels.